### PR TITLE
Fix spelling and description of Ccache

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ template is licensed under the [Unlicense](https://unlicense.org/),
 * Options to build as a header-only library or executable, not just a static or
 shared library.
 
-* **CCache** integration, for speeding up build times
+* **Ccache** integration, for speeding up rebuild times
 
 ## Getting Started
 

--- a/cmake/StandardSettings.cmake
+++ b/cmake/StandardSettings.cmake
@@ -81,7 +81,7 @@ if(${PROJECT_NAME}_ENABLE_LTO)
 endif()
 
 
-option(${PROJECT_NAME}_ENABLE_CCACHE "Enable the usage of CCache, in order to speed up build times." ON)
+option(${PROJECT_NAME}_ENABLE_CCACHE "Enable the usage of Ccache, in order to speed up rebuild times." ON)
 find_program(CCACHE_FOUND ccache)
 if(CCACHE_FOUND)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)


### PR DESCRIPTION
The preferred spelling of Ccache is “Ccache” or “ccache”, not “CCache”. This PR changes it to the former variant. Also, since Ccache only speeds up rebuilds the PR tweaks the description of Ccache to say so.

Closes #7.
