### PR TITLE
Fix clang format target command

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -21,15 +21,18 @@ function(add_clang_format_target)
 			if(${PROJECT_NAME}_BUILD_EXECUTABLE)
 				add_custom_target(clang-format
 						COMMAND ${${PROJECT_NAME}_CLANG_FORMAT_BINARY}
-						-i $${CMAKE_CURRENT_LIST_DIR}/${exe_sources} ${CMAKE_CURRENT_LIST_DIR}/${headers})
+						-i ${exe_sources} ${headers}
+						WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
 			elseif(${PROJECT_NAME}_BUILD_HEADERS_ONLY)
 				add_custom_target(clang-format
 						COMMAND ${${PROJECT_NAME}_CLANG_FORMAT_BINARY}
-						-i ${CMAKE_CURRENT_LIST_DIR}/${headers})
+						-i ${headers}
+						WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
 			else()
 				add_custom_target(clang-format
 						COMMAND ${${PROJECT_NAME}_CLANG_FORMAT_BINARY}
-						-i ${CMAKE_CURRENT_LIST_DIR}/${sources} ${CMAKE_CURRENT_LIST_DIR}/${headers})
+						-i ${sources} ${headers}
+						WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
 			endif()
 
 			message(STATUS "Format the project using the `clang-format` target (i.e: cmake --build build --target clang-format).\n")


### PR DESCRIPTION
closes #21

### Summary

When using multiple sources/headers, the building of the custom target `clang-format` was failing. 

This was fixed by using the `WORKING_DIRECTORY` argument of `add_custom_target`. 

### Side Notes

I know you said you'd fixed this in the next release @filipdutescu, but I thought I'd help you along here. 

Thank you for putting this template together! The world of modern C++ can be extremely confusing, but having a template like this with best practices has already made a world of difference to me! 

### Testing

✅   Able to reproduce error by adding `src/main.cpp` and building as an executable with `${PROJECT_NAME}_BUILD_EXECUTABLE` set to `ON`. This work fixed this error. 
✅   Able to run `clang-format` target with the setup described in the test above

### Pull Request Readiness Checklist

See details at [CONTRIBUTING.md](https://github.com/filipdutescu/modern-cpp-template/blob/master/CONTRIBUTING.md).

* [x] I agree to contribute to the project under modern-cpp-template (Unlicense)
[License](LICENSE).
* [x] To the best of my knowledge, the proposed patch is not based on a code under
GPL or other license that is incompatible with modern-cpp-template
* [x] The PR is proposed to proper branch
* [x] There is reference to original bug report and related work
* [x] There is accuracy test, performance test and test data in the repository,
if applicable
* [x] The feature is well documented and sample code can be built with the project
CMake