### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,11 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 message(STATUS "Started CMake for ${PROJECT_NAME} v${PROJECT_VERSION}...\n")
 
+if (UNIX)
+    add_compile_options("$<$<CONFIG:DEBUG>:-D_DEBUG>")    #this will allow to use same _DEBUG macro available in both Linux as well as Windows - MSCV environment. Easy to put Debug specific code.
+endif (UNIX)
+
+
 #
 # Setup alternative names
 #


### PR DESCRIPTION

PR corresponds to below issue:
https://github.com/filipdutescu/modern-cpp-template/issues/30

It generates _DEBUG macro for LInux Platform so that both Unix and Windows can use same macro: _DEBUG for debug specific code