### PR TITLE
chore(ci): modernize Github Actions

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,20 +17,20 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       
     - name: cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cache
       with:
         path: ${{ github.workspace }}/${{ env.INSTALL_LOCATION }}
-        key: ${{ runner.os }}-dependencies
+        key: ${{ runner.os }}-dependencies-${{ hashFiles('CMakeLists.txt') }}
 
     - name: install GoogleTest
-      if: ${{ steps.cache.output.cache-hit != 'true' }}
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       run: |
         cd ..
-        git clone https://github.com/google/googletest.git --branch release-1.10.0
+        git clone https://github.com/google/googletest.git --branch v1.17.0
         cd googletest
         cmake -Bbuild -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/$INSTALL_LOCATION
         cmake --build build --config Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,32 +44,35 @@ jobs:
     - name: set version name (Windows)
       id: version_win
       if: ${{ runner.os == 'Windows' }}
+      shell: pwsh
       run: |
         $TAG = (${env:GITHUB_REF} -replace 'refs/tags/', '')
-        echo "::set-output name=name::$TAG"
+        echo "name=$TAG" >> ${env:GITHUB_OUTPUT}
     
     - name: set version name
       id: version
       if: ${{ runner.os != 'Windows' }}
-      run: echo ::set-output name=name::${GITHUB_REF#refs/tags/}
+      run: |
+        TAG=${GITHUB_REF#refs/tags/}
+        echo "name=$TAG" >> "$GITHUB_OUTPUT"
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
     - name: cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cache
       with:
         path: ${{ github.HOME }}/.local
-        key: ${{ runner.os }}-dependencies
+        key: ${{ runner.os }}-dependencies-${{ hashFiles('CMakeLists.txt') }}
 
     - name: install GoogleTest
-      if: ${{ steps.cache.output.cache-hit != 'true' }}
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       run: |
         cd ..
-        git clone https://github.com/google/googletest.git --branch release-1.10.0
+        git clone https://github.com/google/googletest.git --branch v1.17.0
         cd googletest
         cmake -Bbuild -DCMAKE_INSTALL_PREFIX="$HOME/.local" -Dgtest_force_shared_crt=1
         cmake --build build --config Release
@@ -104,14 +107,14 @@ jobs:
         tar -cvzf $HOME/artifact.tar.gz .
 
     - name: upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: ${{ runner.os == 'Windows' }}
       with:
         name: ${{ runner.os }}-${{ steps.version_win.outputs.name }}
         path: '~/artifact.*'
 
     - name: upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: ${{ runner.os != 'Windows' }}
       with:
         name: ${{ runner.os }}-${{ steps.version.outputs.name }}
@@ -141,7 +144,7 @@ jobs:
         prerelease: false
 
     - name: download artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: "Linux-${{ steps.version.outputs.name }}"
         path: ./
@@ -157,7 +160,7 @@ jobs:
         asset_content_type: application/x-tar
 
     - name: download artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: "Windows-${{ steps.version.outputs.name }}"
         path: ./
@@ -173,7 +176,7 @@ jobs:
         asset_content_type: application/zip
 
     - name: download artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: "macOS-${{ steps.version.outputs.name }}"
         path: ./

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -17,20 +17,20 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       
     - name: cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cache
       with:
         path: ${{ github.workspace }}/${{ env.INSTALL_LOCATION }}
-        key: ${{ runner.os }}-dependencies
+        key: ${{ runner.os }}-dependencies-${{ hashFiles('CMakeLists.txt') }}
 
     - name: install GoogleTest
-      if: ${{ steps.cache.output.cache-hit != 'true' }}
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       run: |
         cd ..
-        git clone https://github.com/google/googletest.git --branch release-1.10.0
+        git clone https://github.com/google/googletest.git --branch v1.17.0
         cd googletest
         cmake -Bbuild -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/$INSTALL_LOCATION
         cmake --build build --config Release
@@ -47,8 +47,10 @@ jobs:
         cd build
         ctest -C $BUILD_TYPE -VV
 
-    - name: Code coverage using Codecov 
-      run: bash <(curl -s https://codecov.io/bash) 
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        fail_ci_if_error: false
 
     - name: install project
       run: cmake --build build --target install --config Release 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,20 +17,20 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cache
       with:
         path: ${{env.INSTALL_LOCATION}}
-        key: ${{runner.os}}-dependencies
+        key: ${{ runner.os }}-dependencies-${{ hashFiles('CMakeLists.txt') }}
 
     - name: install GoogleTest
       if: ${{steps.cache.output.cache-hit != 'true'}}
       run: |
         cd ..
-        git clone https://github.com/google/googletest.git --branch release-1.10.0
+        git clone https://github.com/google/googletest.git --branch v1.17.0
         cd googletest
         cmake -Bbuild -DCMAKE_INSTALL_PREFIX="$HOME/$env:INSTALL_LOCATION" -Dgtest_force_shared_crt=1
         cmake --build build --config Release

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -3,7 +3,7 @@
 #
 
 function(verbose_message content)
-    if(${PROJECT_NAME}_VERBOSE_OUTPUT)
+    if(${CMAKE_PROJECT_NAME}_VERBOSE_OUTPUT)
 			message(STATUS ${content})
     endif()
 endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,8 +4,6 @@ cmake_minimum_required(VERSION 3.15)
 # Project details
 #
 
-set(${CMAKE_PROJECT_NAME}Tests_VERBOSE_OUTPUT ${PROJECT_NAME}_VERBOSE_OUTPUT)
-
 project(
   ${CMAKE_PROJECT_NAME}Tests
   LANGUAGES CXX


### PR DESCRIPTION
To solve [build failed](https://github.com/filipdutescu/modern-cpp-template/actions/runs/20526520388/job/58970763181)

- Upgrade actions (checkout, cache, upload-artifact, download-artifact) to v4
- Replace legacy ::set-output with GITHUB_OUTPUT in version steps
- Use hashFiles('CMakeLists.txt') in cache key for better invalidation
- Switch to codecov/codecov-acttion@v4 for coverage reporting
- Upgrade GoogleTest from release-1.10.0 to v1.17.0 (requires C++17)
- https://github.com/filipdutescu/modern-cpp-template/issues/49#issuecomment-3693151987

<img width="1301" height="591" alt="image" src="https://github.com/user-attachments/assets/93ab09a4-af2e-41b8-8657-0456beca731f" />
