### PR TITLE
fix(Makefile): use PROJECT_NAME and keep coverage output in build dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ elseif(${PROJECT_NAME}_BUILD_HEADERS_ONLY)
 
   if(${PROJECT_NAME}_VERBOSE_OUTPUT)
     verbose_message("Found the following headers:")
-    foreach(header IN LIST headers)
+    foreach(header IN LISTS headers)
       verbose_message("* ${header}")
     endforeach()
   endif()

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PROJECT_NAME := Project
+
 .PHONY: install coverage test docs help
 .DEFAULT_GOAL := help
 
@@ -32,21 +34,25 @@ help:
 
 test: ## run tests quickly with ctest
 	rm -rf build/
-	cmake -Bbuild -DCMAKE_INSTALL_PREFIX=$(INSTALL_LOCATION) -Dmodern-cpp-template_ENABLE_UNIT_TESTING=1 -DCMAKE_BUILD_TYPE="Release"
+	cmake -Bbuild -DCMAKE_INSTALL_PREFIX=$(INSTALL_LOCATION) \
+		-D$(PROJECT_NAME)_ENABLE_UNIT_TESTING=1 \
+		-DCMAKE_BUILD_TYPE="Release"
 	cmake --build build --config Release
 	cd build/ && ctest -C Release -VV
 
 coverage: ## check code coverage quickly GCC
 	rm -rf build/
-	cmake -Bbuild -DCMAKE_INSTALL_PREFIX=$(INSTALL_LOCATION) -Dmodern-cpp-template_ENABLE_CODE_COVERAGE=1
+	cmake -Bbuild -DCMAKE_INSTALL_PREFIX=$(INSTALL_LOCATION) \
+		-D$(PROJECT_NAME)_ENABLE_CODE_COVERAGE=1
 	cmake --build build --config Release
-	cd build/ && ctest -C Release -VV
-	cd .. && (bash -c "find . -type f -name '*.gcno' -exec gcov -pb {} +" || true)
+	cd build/ && ctest -C Release -VV; \
+		(bash -c "find . -type f -name '*.gcno' -exec gcov -pb {} +" || true)
 
 docs: ## generate Doxygen HTML documentation, including API docs
 	rm -rf docs/
 	rm -rf build/
-	cmake -Bbuild -DCMAKE_INSTALL_PREFIX=$(INSTALL_LOCATION) -DProject_ENABLE_DOXYGEN=1
+	cmake -Bbuild -DCMAKE_INSTALL_PREFIX=$(INSTALL_LOCATION) \
+		-D$(PROJECT_NAME)_ENABLE_DOXYGEN=1
 	cmake --build build --config Release
 	cmake --build build --target doxygen-docs
 	$(BROWSER) docs/html/index.html


### PR DESCRIPTION
- Fix [issue#52](https://github.com/filipdutescu/modern-cpp-template/issues/52)
  - Introduce PROJECT_NAME := Project to avoid hardcoding project name in CMake options
  - Replace hardcoded names like modern-cpp-template_ENABLE_... with $(PROJECT_NAME)_ENABLE_...
  - run gcov inside the build/ directory so .gcov files are not spilled into the project root
- Fix [issue#19](https://github.com/filipdutescu/modern-cpp-template/issues/39)

Improves maintainability and keeps generated files isolated in the build directory.